### PR TITLE
Fix 'chat.db not found' and quotation mark issues

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
 PASSWORD=password
 YOUR_NAME=your-name
 PORT_NUMBER=5000
+DB_FILEPATH=/Users/$user/Library/Messages/chat.db

--- a/Readme.md
+++ b/Readme.md
@@ -42,11 +42,12 @@ pip install -r requirements.txt
 python3 icloud_parser.py
 ```
 
-Now rename ".env.template" to ".env"and set a  password, your name, and port number for this to run off
+Now rename ".env.template" to ".env"and set a  password, your name, and port number for this to run off. Replace `$user` in `DB_FILEPATH` with your user account name.
 ```
 PASSWORD=password
 YOUR_NAME=your-name
 PORT_NUMBER=5000
+DB_FILEPATH=/Users/$user/Library/Messages/chat.db
 ```
 
 Now to run to run the api server, run the following command

--- a/server.py
+++ b/server.py
@@ -19,10 +19,11 @@ def require_api_key(f):
 
 global messages
 
+DB_FILEPATH=os.environ.get('DB_FILEPATH')
 def update_fd():
     global messages
     while True:
-        messages = sorted(fetch_data.FetchData().get_messages(), key=sort_key, reverse=True)
+        messages = sorted(fetch_data.FetchData(DB_FILEPATH).get_messages(), key=sort_key, reverse=True)
         time.sleep(5)
 threading.Thread(target=update_fd).start()
 

--- a/server.py
+++ b/server.py
@@ -49,6 +49,7 @@ def sort_key(item):
     return datetime.strptime(item[2], '%Y-%m-%d %H:%M:%S')
 
 def send(phone_number, message):
+    message = message.replace('"', '\\"')
     applescript = f'''
     tell application "Messages"
         set targetService to 1st service whose service type = iMessage


### PR DESCRIPTION
This PR fixes an issue where chat.db cannot be found by the programme (because the filepath is not specified), as well as solving an issue where quotation marks in the message would not be escaped and would break the AppleScript.